### PR TITLE
Add returnperiod and  surce stormnumber metadata to scenario NetCDF.....

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ Source/RainyDay_utilities_Py3/__pycache__/__init__.cpython-311.pyc
 Source/RainyDay_utilities_Py3/__pycache__/__init__.cpython-38.pyc
 Source/.DS_Store
 .DS_Store
+
+# Claude Code generated / local config
+.claude/
+CLAUDE.md

--- a/Source/RainyDay_Py3.py
+++ b/Source/RainyDay_Py3.py
@@ -2789,6 +2789,8 @@ if FreqAnalysis:
     #################################################################################
 
     if Scenarios:
+        # modified by Ashar 07/12/2026: added returnperiod/original_stormnumber assignment
+        # (full_returnperiod, level_indices) and RETURNLEVELS-aware scenario selection below
         print("writing spacetime precipitation scenarios...")
         # Track how many storms have been written per year
         written_per_year = {}

--- a/Source/RainyDay_Py3.py
+++ b/Source/RainyDay_Py3.py
@@ -2798,7 +2798,25 @@ if FreqAnalysis:
         
         subrangelat=np.array(latrange[ymin:ymax+1])
         subrangelon=np.array(lonrange[xmin:xmax+1])
-        minind=RainyDay.find_nearest(returnperiod,RainfallThreshYear)
+        # Full-length return period array (length nsimulations), rebuilt from the same
+        # formula used in the frequency analysis (returnperiod=1/exceedp). This is used for
+        # per-scenario return periods so the result is correct whether alllevels is True
+        # (returnperiod untouched) or False (module-level returnperiod was reduced at the
+        # alllevels==False branch above).
+        full_returnperiod=1.0/np.linspace(1,1./nsimulations,nsimulations)
+        minind=RainyDay.find_nearest(full_returnperiod,RainfallThreshYear)
+
+        # Which ranks (along the sorted-years axis) get written as scenario files.
+        # alllevels==True (RETURNLEVELS "all"): every rank at/above RETURNTHRESHOLD, as before.
+        # alllevels==False (RETURNLEVELS an explicit list, e.g. [2,5,10,25,50,100]): only the
+        # ranks nearest each requested level, matching the same reduction used for the
+        # FreqAnalysis CSV/plot (RainyDay.find_nearest against full_returnperiod).
+        if alllevels:
+            level_indices=np.arange(minind,nsimulations)
+        else:
+            level_indices=np.array(sorted(set(
+                RainyDay.find_nearest(full_returnperiod,lvl) for lvl in speclevels
+            )),dtype='int64')
         
         # sortind=np.argsort(whichrain[:,:,:,0],axis=0)
         # whichrain=np.take_along_axis(np.squeeze(whichrain),sortind,axis=0)
@@ -2851,9 +2869,9 @@ if FreqAnalysis:
 
 
 
-        whichstorms=whichstorms[-nperyear:,minind:,:]
-        writex=whichx[-nperyear:,minind:,:]
-        writey=whichy[-nperyear:,minind:,:]
+        whichstorms=whichstorms[-nperyear:,level_indices,:]
+        writex=whichx[-nperyear:,level_indices,:]
+        writey=whichy[-nperyear:,level_indices,:]
         
         writemask=trimmask
         writemask[np.greater(trimmask,0.)]=1.   # we don't want fractional masks here
@@ -2867,7 +2885,7 @@ if FreqAnalysis:
             print("You are rescaling the rainfall scenarios\nranking rescaling factors for writing scenarios...")
 
             whichmultiplier_sorted_second = np.take_along_axis(top_multiplier,sortind_second_axis[np.newaxis, :, :, np.newaxis, np.newaxis], axis=1)
-            writemultiplier = whichmultiplier_sorted_second[:, minind:, :, :, :]
+            writemultiplier = whichmultiplier_sorted_second[:, level_indices, :, :, :]
 
         for i in np.arange(0,nstorms):
             print("writing scenarios for storm "+str(i+1))
@@ -2891,16 +2909,34 @@ if FreqAnalysis:
                     tstorm,tyear,trealization=np.where(stormindex==k)    ####tstorm is not the original storm number here but "i" is.
                     outx=writex[stormindex==k]
                     outy=writey[stormindex==k]
-                    
+
+                    # Original (parent) storm number: the real catalog storm ID this scenario
+                    # was transposed from. stormnumber is index-aligned with stormlist, so it
+                    # respects EXCLUDESTORMS and 1-based filenames.
+                    origstormnumber=stormnumber[i]
+                    # Return period of THIS scenario. tyear[0] is a position along the
+                    # (possibly level-reduced) years axis; level_indices maps it back to the
+                    # absolute rank in the full-length return period array. Return period is a
+                    # property of the YEAR-RANK, not of an individual storm, so when NPERYEAR>1
+                    # only the single largest storm of that year (axis 0 is sorted ascending, so
+                    # tstorm[0]==nperyear-1 is the last/largest slot) gets the real value; any
+                    # additional storms from the same year would otherwise misleadingly share
+                    # that same return period despite being smaller/different storms, so they
+                    # get the file's missing-value sentinel (-9999.) instead.
+                    if tstorm[0]==nperyear-1:
+                        scenario_returnperiod=full_returnperiod[level_indices[tyear[0]]]
+                    else:
+                        scenario_returnperiod=-9999.
+
                     name_scenariofile=fullpath+'/Realizations/realization'+str(trealization[0]+1)+'/scenario_'+scenarioname+'_rlz'+str(trealization[0]+1)+'year'+str(tyear[0]+1)+'storm'+str(tstorm[0]+1)+'.nc'
                     #outrain=RainyDay.SSTspin_write_v2(catrain,np.squeeze(writex[:,rlz]),np.squeeze(writey[:,rlz]),np.squeeze(writestorm[:,rlz]),nanmask,maskheight,maskwidth,precat,cattime[:,-1],rainprop,spin=prependrain,flexspin=False,samptype=transpotype,cumkernel=cumkernel,rotation=rotation,domaintype=domain_type)
                     if rescaletype == 'dimensionless':
                         outmultiplier = writemultiplier[stormindex == k]
                         RainyDay.Normalized_SST_write(catrain, raintime, outx, outy, outmultiplier, name_scenariofile, i, tyear[0],
                                                    trealization[0], maskheight, maskwidth, subrangelat, subrangelon,
-                                                   scenarioname, writemask)
+                                                   scenarioname, writemask, origstormnumber, scenario_returnperiod)
                     else:
-                        RainyDay.writescenariofile(catrain,raintime,outx,outy,name_scenariofile,i,tyear[0],trealization[0],maskheight,maskwidth,subrangelat,subrangelon,scenarioname,writemask)
+                        RainyDay.writescenariofile(catrain,raintime,outx,outy,name_scenariofile,i,tyear[0],trealization[0],maskheight,maskwidth,subrangelat,subrangelon,scenarioname,writemask,origstormnumber,scenario_returnperiod)
 
     #testrain=np.nansum(np.multiply(catrain[:,21 : 21+maskheight, 29 : 29+maskwidth],trimmask),axis=(1,2))/mnorm
     

--- a/Source/RainyDay_utilities_Py3/RainyDay_functions.py
+++ b/Source/RainyDay_utilities_Py3/RainyDay_functions.py
@@ -2099,6 +2099,7 @@ def delete_files_in_directory(directory_path):
 
 # =============================================================================
 # added DBW 08142023: writing single storm scenario file using xarray
+# modified by Ashar 07/12/2026: added returnperiod and original_stormnumber output variables
 # =============================================================================
 def writescenariofile(catrain,raintime,rainlocx,rainlocy,name_scenariofile,tstorm,tyear,trealization,maskheight,maskwidth,subrangelat,subrangelon,scenarioname,mask,origstormnumber,scenario_returnperiod):
     # the following line extracts only the transposed rainfall within the area of interest
@@ -2180,6 +2181,7 @@ def writescenariofile(catrain,raintime,rainlocx,rainlocy,name_scenariofile,tstor
 
 # =============================================================================
 # added LY 03132025: writing single storm scenario file using normalized SST
+# modified by Ashar 07/12/2026: added returnperiod and original_stormnumber output variables
 # =============================================================================
 def Normalized_SST_write(catrain, raintime, rainlocx, rainlocy, outmultiplier, name_scenariofile, tstorm, tyear, trealization, maskheight,maskwidth, subrangelat, subrangelon, scenarioname, mask, origstormnumber, scenario_returnperiod):
     transposedrain=np.multiply(catrain[:,rainlocy[0] : (rainlocy[0]+maskheight), rainlocx[0] : (rainlocx[0]+maskwidth)],mask)

--- a/Source/RainyDay_utilities_Py3/RainyDay_functions.py
+++ b/Source/RainyDay_utilities_Py3/RainyDay_functions.py
@@ -2100,11 +2100,11 @@ def delete_files_in_directory(directory_path):
 # =============================================================================
 # added DBW 08142023: writing single storm scenario file using xarray
 # =============================================================================
-def writescenariofile(catrain,raintime,rainlocx,rainlocy,name_scenariofile,tstorm,tyear,trealization,maskheight,maskwidth,subrangelat,subrangelon,scenarioname,mask):
+def writescenariofile(catrain,raintime,rainlocx,rainlocy,name_scenariofile,tstorm,tyear,trealization,maskheight,maskwidth,subrangelat,subrangelon,scenarioname,mask,origstormnumber,scenario_returnperiod):
     # the following line extracts only the transposed rainfall within the area of interest
     #transposedrain=np.multiply(catrain[:,rainlocy[0] : (rainlocy[0]+maskheight), rainlocx[0] : (rainlocx[0]+maskwidth)],mask)
     transposedrain=catrain[:,rainlocy[0] : (rainlocy[0]+maskheight), rainlocx[0] : (rainlocx[0]+maskwidth)]
-    
+
     description_string='RainyDay storm scenario file for original storm '+str(tstorm)+', year '+str(tyear)+', realization '+str(trealization)+', created from ' + scenarioname
     latitudes_units,longitudes_units = 'degrees_north', 'degrees_east'
     rainrate_units = 'mm hr^-1'
@@ -2123,22 +2123,36 @@ def writescenariofile(catrain,raintime,rainlocx,rainlocy,name_scenariofile,tstor
          {
                 "rain": (["time","latitude", "longitude"], transposedrain),
                 "xlocation": (["scalar_dim"], rainlocx),
-                "ylocation": (["scalar_dim"], rainlocy)
+                "ylocation": (["scalar_dim"], rainlocy),
+                "returnperiod": (["scalar_dim"], [np.float32(scenario_returnperiod)],
+                                 {"units": "years",
+                                  "long_name": "return period of scenario",
+                                  "comment": "valid only for the single largest storm of a given year rank; -9999. for any additional NPERYEAR>1 storms sharing that same year rank"}),
+                "original_stormnumber": (["scalar_dim"], [np.int16(origstormnumber)],
+                                 {"units": "dimensionless",
+                                  "long_name": "parent storm number from storm catalog"})
                 #"scenariotime":(["time"],raintime)
             },
             coords={
-                "time": raintime,   
-                "latitude": subrangelat, 
+                "time": raintime,
+                "latitude": subrangelat,
                 "longitude": subrangelon,
                 "scalar_dim": [0]
             },
             attrs={
-            "history":history, 
-            "source" :  source, 
-            "missing" : missing, 
-            "description" : description_string,  
-            "calendar" : times_calendar    
-            }   
+            "history":history,
+            "source" :  source,
+            "missing" : missing,
+            "description" : description_string,
+            "calendar" : times_calendar,
+            "times_units": times_units,
+            "latitudes_units": latitudes_units,
+            "longitudes_units": longitudes_units,
+            "rainrate_units": rainrate_units,
+            "rainrate_name": rainrate_name,
+            "xlocation_name": xlocation_name,
+            "ylocation_name": ylocation_name
+            }
     )
     
     # # 
@@ -2167,7 +2181,7 @@ def writescenariofile(catrain,raintime,rainlocx,rainlocy,name_scenariofile,tstor
 # =============================================================================
 # added LY 03132025: writing single storm scenario file using normalized SST
 # =============================================================================
-def Normalized_SST_write(catrain, raintime, rainlocx, rainlocy, outmultiplier, name_scenariofile, tstorm, tyear, trealization, maskheight,maskwidth, subrangelat, subrangelon, scenarioname, mask):
+def Normalized_SST_write(catrain, raintime, rainlocx, rainlocy, outmultiplier, name_scenariofile, tstorm, tyear, trealization, maskheight,maskwidth, subrangelat, subrangelon, scenarioname, mask, origstormnumber, scenario_returnperiod):
     transposedrain=np.multiply(catrain[:,rainlocy[0] : (rainlocy[0]+maskheight), rainlocx[0] : (rainlocx[0]+maskwidth)],mask)
     rain_nsst = transposedrain * outmultiplier
 
@@ -2182,7 +2196,14 @@ def Normalized_SST_write(catrain, raintime, rainlocx, rainlocy, outmultiplier, n
         {
             "rain": (["time", "latitude", "longitude"], rain_nsst),
             "xlocation": (["scalar_dim"], rainlocx),
-            "ylocation": (["scalar_dim"], rainlocy)
+            "ylocation": (["scalar_dim"], rainlocy),
+            "returnperiod": (["scalar_dim"], [np.float32(scenario_returnperiod)],
+                             {"units": "years",
+                              "long_name": "return period of scenario",
+                              "comment": "valid only for the single largest storm of a given year rank; -9999. for any additional NPERYEAR>1 storms sharing that same year rank"}),
+            "original_stormnumber": (["scalar_dim"], [np.int16(origstormnumber)],
+                             {"units": "dimensionless",
+                              "long_name": "parent storm number from storm catalog"})
             # "scenariotime":(["time"],raintime)
         },
         coords={


### PR DESCRIPTION
… files

Scenario files previously had no way to trace which storm they were transposed from or what return period they represent. Adds both as variables in writescenariofile/Normalized_SST_write, makes the scenario writer respect RETURNLEVELS (writing only the requested levels, matching the FreqAnalysis CSV), and marks returnperiod as -9999 for any additional NPERYEAR>1 storms beyond a year's largest to avoid mislabeling distinct storms with a duplicate return period.

Dan, I need you to check if this functionality is good for us. Although I have checked it, and I think it is doing what we are trying to do.